### PR TITLE
writer: RLock while exporting playlist count

### DIFF
--- a/structure.go
+++ b/structure.go
@@ -119,10 +119,10 @@ type MediaPlaylist struct {
 	count          uint // number of segments added to the playlist
 	buf            bytes.Buffer
 	ver            uint8
-	Key            *Key        // EXT-X-KEY is optional encryption key displayed before any segments (default key for the playlist)
-	Map            *Map        // EXT-X-MAP is optional tag specifies how to obtain the Media Initialization Section (default map for the playlist)
-	WV             *WV         // Widevine related tags outside of M3U8 specs
-	lock           *sync.Mutex // protects `buf` during it's generation
+	Key            *Key          // EXT-X-KEY is optional encryption key displayed before any segments (default key for the playlist)
+	Map            *Map          // EXT-X-MAP is optional tag specifies how to obtain the Media Initialization Section (default map for the playlist)
+	WV             *WV           // Widevine related tags outside of M3U8 specs
+	lock           *sync.RWMutex // protects `buf` during it's generation
 	// modification of `head`, `tail` and `count` should be protected by `lock`
 	dirty bool // indicates that `buf` should be regenerated
 }

--- a/writer.go
+++ b/writer.go
@@ -274,7 +274,7 @@ func NewMediaPlaylist(winsize uint, capacity uint) (*MediaPlaylist, error) {
 		return nil, err
 	}
 	p.Segments = make([]*MediaSegment, capacity)
-	p.lock = &sync.Mutex{}
+	p.lock = &sync.RWMutex{}
 	p.Live = true
 	return p, nil
 }
@@ -730,6 +730,8 @@ func (p *MediaPlaylist) DurationAsInt(yes bool) {
 
 // Count tells us the number of items that are currently in the media playlist
 func (p *MediaPlaylist) Count() uint {
+	p.lock.RLock()
+	defer p.lock.RUnlock()
 	return p.count
 }
 


### PR DESCRIPTION
Use RWMutex and read-lock it when exporting the value of `MediaPlaylist.count`
A race condition was found here - https://github.com/livepeer/go-livepeer/pull/1672#issuecomment-739001491